### PR TITLE
Add svg width to fix it's behavior in firefox on nav hover

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -78,6 +78,7 @@ main {
 }
 
 .nav-link svg {
+  width: 2rem;
   min-width: 2rem;
   margin: 0 1.5rem;
 }


### PR DESCRIPTION
When the navbar is hovered in firefox 73, the width and height of the svg icons increases to about 140px.
This breaks the desired positions of the spans '.link-text' elements to be far more to the right.
And it also makes the svg icons to be almost on top of each other, due to its big size.

Thus, this commit fixes those problems with the 'width' set to the same value of the 'min-width' property on those svg icons.