### PR TITLE
Fix selected and default classes enabled at reload

### DIFF
--- a/public/theme.js
+++ b/public/theme.js
@@ -4,7 +4,10 @@ const themeMap = {
   solar: "dark"
 };
 
-const theme = localStorage.getItem('theme') || Object.keys(themeMap)[0];
+const theme = localStorage.getItem('theme')
+  || (tmp = Object.keys(themeMap)[0],
+      localStorage.setItem('theme', tmp),
+      tmp);
 const bodyClass = document.body.classList;
 bodyClass.add(theme);
 

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,12 +1,11 @@
 const themeMap = {
-  dark: 'light',
-  light: 'solar',
-  solar: 'dark'
+  dark: "light",
+  light: "dark",
 };
 
-const theme = localStorage.getItem('theme');
+const theme = localStorage.getItem('theme') || Object.keys(themeMap)[0];
 const bodyClass = document.body.classList;
-theme && bodyClass.add(theme) || (bodyClass.add("dark"), localStorage.setItem('theme', "dark"));
+bodyClass.add(theme);
 
 function toggleTheme() {
   const current = localStorage.getItem('theme');

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,6 +1,7 @@
 const themeMap = {
   dark: "light",
-  light: "dark",
+  light: "solar",
+  solar: "dark"
 };
 
 const theme = localStorage.getItem('theme') || Object.keys(themeMap)[0];


### PR DESCRIPTION
I also made this less hardcoded by selecting the first element of themeMap as default value (instead of "dark").

Love your work btw :D