### PR TITLE
Fix media queries overlap.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -152,7 +152,7 @@ main {
 }
 
 /* Large screens */
-@media only screen and (min-width: 600px) {
+@media only screen and not (max-width: 600px) {
   .navbar {
     top: 0;
     width: 5rem;


### PR DESCRIPTION
As BoltClock [pointed out](https://stackoverflow.com/questions/13634326/how-can-i-avoid-media-query-overlap#answer-13649011) in StackOverflow, using `not` is the only reliable way to avoid media queries overlap.