### PR TITLE
Remove Overflow: scroll, Fix Transition var, Add .link-text transition

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -36,7 +36,6 @@ main {
   position: fixed;
   background-color: var(--bg-primary);
   transition: width 600ms ease;
-  overflow: scroll;
 }
 
 .navbar-nav {

--- a/public/style.css
+++ b/public/style.css
@@ -35,7 +35,7 @@ main {
 .navbar {
   position: fixed;
   background-color: var(--bg-primary);
-  transition: width 600ms ease;
+  transition: width var(--transition-speed) ease;
 }
 
 .navbar-nav {

--- a/public/style.css
+++ b/public/style.css
@@ -73,8 +73,11 @@ main {
 }
 
 .link-text {
-  display: none;
+  display: inline;
   margin-left: 1rem;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity var(--transition-speed), visibility var(--transition-speed);
 }
 
 .nav-link svg {
@@ -145,6 +148,10 @@ main {
     justify-content: center;
   }
 
+  .link-text {
+    display: none;
+  }
+
   main {
     margin: 0;
   }
@@ -164,6 +171,8 @@ main {
 
   .navbar:hover .link-text {
     display: inline;
+    opacity: 1;
+    visibility: visible;
   }
 
   .navbar:hover .logo svg


### PR DESCRIPTION
Hi!
I tried to fix some project issues.
Honestly I don't know why you merged to master a commit where overflow: scroll was applied to '.navbar', it literally broke the navbar layout as you can see in the gif. 
![overflowfix](https://user-images.githubusercontent.com/32676891/95368215-18618580-08d6-11eb-90d6-5de3b2a77992.gif)

Secondly I fixed the transition time in .navbar since it was set as a constant of 600ms, I switched the value with the variable we previously declared at the start of the .css document.

Lastly, I made sure that the .link-text appears only when it doesn't exceed the navbar border while it's expanding on hover by using a combination of CSS properties like visibility, opacity and transition for both of them.
